### PR TITLE
Update hooks.tsx

### DIFF
--- a/src/core/color-mode/hooks.tsx
+++ b/src/core/color-mode/hooks.tsx
@@ -22,7 +22,7 @@ export const useColorMode = (): IColorModeContextProps => {
   return colorModeContext;
 };
 
-export function useColorModeValue(light: any, dark: any) {
+export function useColorModeValue<ValueType>(light: ValueType, dark: ValueType) {
   const { colorMode } = useColorMode();
   return colorMode === 'dark' ? dark : light;
 }


### PR DESCRIPTION
Add generic type for params of hook `useColorModeValue` This will make the hook return type is specific instead of `any`

E.g:
```
const textColor = useColorModeValue("dark.900", "light.900"); // type of textColor is string
```

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[CATEGORY] [TYPE] - Message

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
